### PR TITLE
Add documentation generation

### DIFF
--- a/docs/event-manager/event-manager.md
+++ b/docs/event-manager/event-manager.md
@@ -1,0 +1,12 @@
+### Summary
+* [EventManager](#eventmanager)
+
+### EventManager
+
+```lua
+global EventManager: EventManagerRecord
+```
+
+
+
+---

--- a/docs/event-manager/event.md
+++ b/docs/event-manager/event.md
@@ -1,0 +1,18 @@
+### Summary
+* [Event](#event)
+
+### Event
+
+```lua
+global Event = @record {
+	-- Strings
+	name: string,
+	
+	-- Booleans
+	fired: boolean,
+}
+```
+
+
+
+---

--- a/docs/event/event.md
+++ b/docs/event/event.md
@@ -1,0 +1,18 @@
+### Summary
+* [Event](#event)
+
+### Event
+
+```lua
+global Event = @record {
+	-- Strings
+	name: string,
+	
+	-- Booleans
+	fired: boolean,
+}
+```
+
+
+
+---

--- a/docs/fileystem/filesystem.md
+++ b/docs/fileystem/filesystem.md
@@ -1,0 +1,233 @@
+### Summary
+* [fs](#fs)
+* [fs.sep](#fssep)
+* [fs.StatKind](#fsstatkind)
+* [fs.StatInfo](#fsstatinfo)
+* [fs.isdir](#fsisdir)
+* [fs.isfile](#fsisfile)
+* [fs.cwdir](#fscwdir)
+* [fs.chdir](#fschdir)
+* [fs.chmod](#fschmod)
+* [fs.chown](#fschown)
+* [fs.mkdir](#fsmkdir)
+* [fs.mkfile](#fsmkfile)
+* [fs.mklink](#fsmklink)
+* [fs.rmdir](#fsrmdir)
+* [fs.rmfile](#fsrmfile)
+* [fs.move](#fsmove)
+* [fs.touch](#fstouch)
+* [fs.stat](#fsstat)
+* [fs.readfile](#fsreadfile)
+* [fs.readlink](#fsreadlink)
+* [fs.cpfile](#fscpfile)
+
+## filesystem
+
+File system module.
+
+Contains various utilities to manages files, directories and links.
+
+Most functions from this library returns 3 values:
+* First is the operation result, which may be false or empty in case the operation failed.
+* Second is an error message, in case the operation failed.
+* Third is a system dependent error code, which is zero when the operation succeeds.
+
+### fs
+
+```lua
+global fs = @record{}
+```
+
+The file system namespace.
+
+### fs.sep
+
+```lua
+global fs.sep: string
+```
+
+Character separator for directories.
+
+### fs.StatKind
+
+```lua
+global fs.StatKind = @enum(uint32){
+  INVALID = 0,
+  FILE,
+  DIRECTORY,
+  LINK,
+  SOCKET,
+  PIPE,
+  CHARACTER,
+  BLOCK,
+  OTHER,
+}
+```
+
+File status kind.
+
+### fs.StatInfo
+
+```lua
+global fs.StatInfo = @record{
+  kind: fs.StatKind,
+  dev: uint64,
+  ino: uint64,
+  nlink: uint64,
+  mode: uint32,
+  uid: uint32,
+  gid: uint32,
+  rdev: uint64,
+  size: int64,
+  atime: int64,
+  mtime: int64,
+  ctime: int64,
+  blksize: int64, -- not available in Windows
+  blocks: int64, -- not available in Windows
+}
+```
+
+File status information.
+
+### fs.isdir
+
+```lua
+function fs.isdir(path: string): boolean
+```
+
+Checks if a directory exists.
+
+### fs.isfile
+
+```lua
+function fs.isfile(path: string): boolean
+```
+
+Checks if a file exists.
+
+### fs.cwdir
+
+```lua
+function fs.cwdir(): (string, string, integer)
+```
+
+Returns the current working directory.
+
+### fs.chdir
+
+```lua
+function fs.chdir(path: string): (boolean, string, integer)
+```
+
+Changes the current working directory.
+
+### fs.chmod
+
+```lua
+function fs.chmod(path: string, mode: uint32): (boolean, string, integer)
+```
+
+Changes permissions of a file.
+
+### fs.chown
+
+```lua
+function fs.chown(path: string, uid: uint32, gid: uint32): (boolean, string, integer)
+```
+
+Changes ownership of a file.
+
+### fs.mkdir
+
+```lua
+function fs.mkdir(path: string): (boolean, string, integer)
+```
+
+Creates a directory.
+
+### fs.mkfile
+
+```lua
+function fs.mkfile(path: string, contents: facultative(string)): (boolean, string, integer)
+```
+
+Creates a file into `path` and write `contents`.
+If `contents` is not present then an empty is created.
+If the file exists, it will be overwritten.
+
+### fs.mklink
+
+```lua
+function fs.mklink(oldpath: string, newpath: string, hard: facultative(boolean)): (boolean, string, integer)
+```
+
+Creates a link for object `oldpath` at `newpath`.
+By default symbolic links are created, unless `hardlink` is true.
+
+### fs.rmdir
+
+```lua
+function fs.rmdir(path: string): (boolean, string, integer)
+```
+
+Removes a directory.
+
+### fs.rmfile
+
+```lua
+function fs.rmfile(path: string): (boolean, string, integer)
+```
+
+Removes a file.
+
+### fs.move
+
+```lua
+function fs.move(oldpath: string, newpath: string): (boolean, string, integer)
+```
+
+Moves a file or directory.
+
+### fs.touch
+
+```lua
+function fs.touch(path: string): (boolean, string, integer)
+```
+
+Updates access and modification time of a file.
+
+### fs.stat
+
+```lua
+function fs.stat(path: string, linkstat: facultative(boolean)): (fs.StatInfo, string, integer)
+```
+
+Gets file status information.
+
+### fs.readfile
+
+```lua
+function fs.readfile(path: string): (string, string, integer)
+```
+
+Reads all contents from a file.
+
+### fs.readlink
+
+```lua
+function fs.readlink(path: string): (string, string, integer)
+```
+
+Reads value from a symbolic link file.
+
+### fs.cpfile
+
+```lua
+function fs.cpfile(oldpath: string, newpath: string): (boolean, string, integer)
+```
+
+Copies file from `oldpath` to `newpath`.
+If a file exists in `newpath`, it will be overwritten.
+File permissions are preserved.
+
+---

--- a/docs/gui/gui.md
+++ b/docs/gui/gui.md
@@ -1,0 +1,246 @@
+### Summary
+* [Widget](#widget)
+* [UIWindow](#uiwindow)
+* [Widget:Init](#widgetinit)
+* [Widget:UpdateVW](#widgetupdatevw)
+* [Widget:SetColors](#widgetsetcolors)
+* [Widget:SetText](#widgetsettext)
+* [Widget:SetWidgetType](#widgetsetwidgettype)
+* [Widget:SetFontSize](#widgetsetfontsize)
+* [Widget:SetPosition](#widgetsetposition)
+* [Widget:SetSize](#widgetsetsize)
+* [Widget:SetBorderSize](#widgetsetbordersize)
+* [Widget:SetAlwaysDrawn](#widgetsetalwaysdrawn)
+* [Widget:SetAutoSize](#widgetsetautosize)
+* [Widget:Draw](#widgetdraw)
+* [Widget:Update](#widgetupdate)
+* [UIWindow:Init](#uiwindowinit)
+* [UIWindow:Update](#uiwindowupdate)
+* [UIWindow:Draw](#uiwindowdraw)
+
+### Widget
+
+```lua
+global Widget = @record {
+
+	-- Strings
+	widgetName: string, --
+	widgetType: string, --
+
+	widgetText: string, --
+
+	-- Cints	
+	fontSize: cint, --
+
+	-- Vector2s
+	position: Vector2, --
+	size: Vector2, --
+
+	-- Engine dealt Cints
+	borderSize: cint, --
+
+	-- Booleans
+	spaceOccupied: boolean,
+
+	-- Engine dealt Colours
+	borderColor: Color,
+	bgColor: Color,
+	fgColor: Color,
+
+	-- Engine dealt Vector2s
+	tl: Vector2,
+	br: Vector2,
+
+	tlW: Vector2,
+	brW: Vector2,
+
+	windowPosition: Vector2,
+
+	-- Engine dealt Booleans
+	isHighlighted: boolean,
+	alwaysDrawn: boolean,
+	autoSize: boolean,
+	isShown: boolean,
+	isDown: boolean,
+}
+```
+
+
+
+### UIWindow
+
+```lua
+global UIWindow = @record {
+
+	-- Strings
+	menuBarText: string,
+	windowName: string,
+
+	-- Vector2s
+	size: Vector2,
+	pos: Vector2,
+
+	-- Colors
+	borderColor: Color,
+	bgColor: Color,
+	fgColor: Color,
+
+	-- Cints
+	nextWidgetSpotAvailable: cint,
+	menuTextPadding: cint,
+	menuFontSize: cint,
+	menuBarSize: cint,
+	borderSize: cint,
+	
+	-- Booleans
+	menuBarEnabled: boolean,
+	
+	-- Uninitialised Booleans
+	spaceOccupied: boolean,
+	isShown: boolean,
+	moving: boolean,
+
+	-- Widgets
+	Widgets: vector(Widget),
+	widgetSpotsAvailable: vector(boolean),
+
+	-- Uninitialised Vector2s
+	originalPosition: Vector2,
+	mouseOffset: Vector2,
+
+	-- Uninitialised Cints
+	grabDebounce: cint,
+}
+```
+
+
+
+### Widget:Init
+
+```lua
+function Widget:Init()
+```
+
+
+
+### Widget:UpdateVW
+
+```lua
+function Widget:UpdateVW()
+```
+
+
+
+### Widget:SetColors
+
+```lua
+function Widget:SetColors(uBorderColor: Color, uFGColor: Color, uBGColor: Color)
+```
+
+
+
+### Widget:SetText
+
+```lua
+function Widget:SetText(uWidgetText: string): *Widget
+```
+
+
+
+### Widget:SetWidgetType
+
+```lua
+function Widget:SetWidgetType(uWidgetType: string): *Widget
+```
+
+
+
+### Widget:SetFontSize
+
+```lua
+function Widget:SetFontSize(uWidgetFontSize: cint): *Widget
+```
+
+
+
+### Widget:SetPosition
+
+```lua
+function Widget:SetPosition(uWidgetPosition: Vector2): *Widget
+```
+
+
+
+### Widget:SetSize
+
+```lua
+function Widget:SetSize(uWidgetSize: Vector2): *Widget
+```
+
+
+
+### Widget:SetBorderSize
+
+```lua
+function Widget:SetBorderSize(uWidgetBorderSize: cint): *Widget
+```
+
+
+
+### Widget:SetAlwaysDrawn
+
+```lua
+function Widget:SetAlwaysDrawn(uWidgetAlwaysDrawn: boolean): *Widget
+```
+
+
+
+### Widget:SetAutoSize
+
+```lua
+function Widget:SetAutoSize(uWidgetAutoSize: boolean): *Widget
+```
+
+
+
+### Widget:Draw
+
+```lua
+function Widget:Draw()
+```
+
+
+
+### Widget:Update
+
+```lua
+function Widget:Update()
+```
+
+
+
+### UIWindow:Init
+
+```lua
+function UIWindow:Init()
+```
+
+
+
+### UIWindow:Update
+
+```lua
+function UIWindow:Update()
+```
+
+
+
+### UIWindow:Draw
+
+```lua
+function UIWindow:Draw()
+```
+
+
+
+---

--- a/docs/gui/gui.md.bak
+++ b/docs/gui/gui.md.bak
@@ -1,0 +1,171 @@
+### Summary
+* [WIDGET_AMOUNT](#widget_amount)
+* [Widget](#widget)
+* [UIWindow](#uiwindow)
+* [Widget:Init](#widgetinit)
+* [Widget:UpdateVW](#widgetupdatevw)
+* [Widget:Draw](#widgetdraw)
+* [Widget:Update](#widgetupdate)
+* [UIWindow:Init](#uiwindowinit)
+* [UIWindow:Update](#uiwindowupdate)
+* [UIWindow:Draw](#uiwindowdraw)
+
+### WIDGET_AMOUNT
+
+```lua
+global WIDGET_AMOUNT
+```
+
+
+
+### Widget
+
+```lua
+global Widget = @record {
+
+	-- Strings
+	widgetName: string,
+	widgetType: string,
+
+	widgetText: string,
+
+	-- Cints	
+	fontSize: cint,
+
+	-- Vector2s
+	position: Vector2,
+	size: Vector2,
+
+	-- Engine dealt Cints
+	borderSize: cint,
+
+	-- Booleans
+	spaceOccupied: boolean,
+
+	-- Engine dealt Colours
+	borderColor: Color,
+	bgColor: Color,
+	fgColor: Color,
+
+	-- Engine dealt Vector2s
+	tl: Vector2,
+	br: Vector2,
+
+	tlW: Vector2,
+	brW: Vector2,
+
+	windowPosition: Vector2,
+
+	-- Engine dealt Booleans
+	isHighlighted: boolean,
+	isDown: boolean,
+}
+```
+
+
+
+### UIWindow
+
+```lua
+global UIWindow = @record {
+
+	-- Strings
+	menuBarText: string,
+	windowName: string,
+
+	-- Vector2s
+	size: Vector2,
+	pos: Vector2,
+
+	-- Colors
+	borderColor: Color,
+	bgColor: Color,
+	fgColor: Color,
+
+	-- Cints
+	nextWidgetSpotAvailable: cint,
+	menuTextPadding: cint,
+	menuFontSize: cint,
+	menuBarSize: cint,
+	borderSize: cint,
+	
+	-- Booleans
+	menuBarEnabled: boolean,
+	
+	-- Uninitialised Booleans
+	spaceOccupied: boolean,
+	isShown: boolean,
+	moving: boolean,
+
+	-- Uninitialised Cints
+	grabDebounce: cint,
+
+	-- Widgets
+	Widgets: vector(Widget),
+	widgetSpotsAvailable: vector(boolean),
+
+	-- Uninitialised Vector2s
+	originalPosition: Vector2,
+	mouseOffset: Vector2,
+}
+```
+
+
+
+### Widget:Init
+
+```lua
+function Widget:Init()
+```
+
+
+
+### Widget:UpdateVW
+
+```lua
+function Widget:UpdateVW()
+```
+
+
+
+### Widget:Draw
+
+```lua
+function Widget:Draw()
+```
+
+
+
+### Widget:Update
+
+```lua
+function Widget:Update()
+```
+
+
+
+### UIWindow:Init
+
+```lua
+function UIWindow:Init()
+```
+
+
+
+### UIWindow:Update
+
+```lua
+function UIWindow:Update()
+```
+
+
+
+### UIWindow:Draw
+
+```lua
+function UIWindow:Draw()
+```
+
+
+
+---

--- a/docs/information-handler/information-handler.md
+++ b/docs/information-handler/information-handler.md
@@ -1,0 +1,12 @@
+### Summary
+* [InformationHandler](#informationhandler)
+
+### InformationHandler
+
+```lua
+global InformationHandler: InformationHandlerClass
+```
+
+
+
+---

--- a/docs/mouse/mouse.md
+++ b/docs/mouse/mouse.md
@@ -1,0 +1,16 @@
+### Summary
+* [Mouse](#mouse)
+
+## mouse
+
+Requires raylib
+
+### Mouse
+
+```lua
+global Mouse: MouseClass
+```
+
+
+
+---

--- a/docs/obj2d/object.md
+++ b/docs/obj2d/object.md
@@ -1,0 +1,23 @@
+### Summary
+* [Object](#object)
+* [Object:ResetPosition](#objectresetposition)
+
+### Object
+
+```lua
+global Object = @record{
+	Transform: Transform,
+}
+```
+
+
+
+### Object:ResetPosition
+
+```lua
+function Object:ResetPosition()
+```
+
+
+
+---

--- a/docs/obj3d/object.md
+++ b/docs/obj3d/object.md
@@ -1,0 +1,23 @@
+### Summary
+* [Object](#object)
+* [Object:ResetPosition](#objectresetposition)
+
+### Object
+
+```lua
+global Object = @record{
+	Transform: Transform,
+}
+```
+
+
+
+### Object:ResetPosition
+
+```lua
+function Object:ResetPosition()
+```
+
+
+
+---

--- a/docs/render/render.md
+++ b/docs/render/render.md
@@ -1,0 +1,12 @@
+### Summary
+* [Renderer](#renderer)
+
+### Renderer
+
+```lua
+global Renderer: RendererClass
+```
+
+[[ Create a global renderer ]]
+
+---

--- a/docs/transform/transform.md
+++ b/docs/transform/transform.md
@@ -1,0 +1,16 @@
+### Summary
+* [Transform](#transform)
+
+### Transform
+
+```lua
+global Transform = @record{
+	position: Vector3,
+	size: Vector3,
+	rotation: Vector3,
+}
+```
+
+
+
+---

--- a/docs/uimanager/uimanager.md
+++ b/docs/uimanager/uimanager.md
@@ -1,0 +1,12 @@
+### Summary
+* [UIManager](#uimanager)
+
+### UIManager
+
+```lua
+global UIManager: UIManagerClass
+```
+
+
+
+---

--- a/docs/utilities/init.md
+++ b/docs/utilities/init.md
@@ -1,0 +1,12 @@
+### Summary
+* [Utility](#utility)
+
+### Utility
+
+```lua
+global Utility: UtilityClass
+```
+
+
+
+---

--- a/gen-docs.lua
+++ b/gen-docs.lua
@@ -1,0 +1,59 @@
+local nldoc = require 'nldoc'
+
+local symbol_template = [[
+### $(name)
+
+```lua
+$(code)
+```
+
+$(text)
+
+]]
+
+local function doc(filename, path, docs_path)
+  local emitter = nldoc.Emitter.create()
+
+  if string.find(filename, '.nelua') then
+    print('documenting '..path..filename..'..')
+
+    nldoc.generate_doc(emitter, path..filename, { symbol_template = symbol_template })
+
+    local emitted = emitter:generate()
+
+    local summary = {'### Summary\n'}
+    for title in emitted:gmatch('### ([%s%g]-)\n') do
+      local title_link = title:lower():gsub('[%.%:]', '')
+      table.insert(summary, string.format('* [%s](#%s)\n', title, title_link))
+    end
+
+    local outfilename = filename:gsub('.nelua', '.md')
+
+    nldoc.write_file('docs/'..docs_path..outfilename, table.concat(summary)..'\n'..emitted)
+  end
+end
+
+local function doc_dir(dirname, docs_dir)
+  local ignored_files = {}
+
+  for filename in lfs.dir(dirname) do
+    if not ignored_files[filename] and filename:match('%.nelua$') then
+      doc(filename, dirname, docs_dir)
+    end
+  end
+end
+
+doc_dir('engine/', '')
+doc_dir('engine/event/', 'event/')
+doc_dir('engine/event-manager/', 'event-manager/')
+doc_dir('engine/fileystem/', 'fileystem/')
+doc_dir('engine/gui/', 'gui/')
+doc_dir('engine/information-handler/', 'information-handler/')
+doc_dir('engine/mouse/', 'mouse/')
+doc_dir('engine/obj2d/', 'obj2d/')
+doc_dir('engine/obj3d/', 'obj3d/')
+doc_dir('engine/render/', 'render/')
+doc_dir('engine/transform/', 'transform/')
+doc_dir('engine/uimanager/', 'uimanager/')
+doc_dir('engine/utilities/', 'utilities/')
+

--- a/nldoc.lua
+++ b/nldoc.lua
@@ -1,0 +1,814 @@
+-- LPegRex is the only external dependency.
+local lpegrex = require 'lpegrex'
+
+--------------------------------------------------------------------------------
+-- Utilities.
+
+-- Walk iterator, used by `walk_nodes`.
+local function walk_nodes_iterator(node, parent, parentindex)
+  if node.tag then
+    coroutine.yield(node, parent, parentindex)
+  end
+  for i=1,#node do
+    local v = node[i]
+    if type(v) == 'table' then
+      walk_nodes_iterator(v, node, i)
+    end
+  end
+end
+
+-- Walk all nodes from an AST.
+local function walk_nodes(ast)
+  return coroutine.wrap(walk_nodes_iterator), ast
+end
+
+-- Read a file and return its contents as string.
+local function read_file(filename)
+  local file, err = assert(io.open(filename))
+  local contents = file:read("*a")
+  file:close()
+  return contents
+end
+
+-- Write contents to a file.
+local function write_file(filename, contents)
+  local file, err = assert(io.open(filename,'w'))
+  assert(file:write(contents))
+  assert(file:close())
+  return true
+end
+
+--------------------------------------------------------------------------------
+-- Parser class, used to parse source codes.
+
+local Parser = {}
+local Parser_mt = {__index = Parser}
+
+-- Creates a new Parser.
+function Parser.create(grammar, comments_grammar, errors, defs)
+  local source_patt = lpegrex.compile(grammar, defs)
+  local comments_patt = lpegrex.compile(comments_grammar, defs)
+  return setmetatable({
+    source_patt = source_patt,
+    comments_patt = comments_patt,
+    errors = errors,
+  }, Parser_mt)
+end
+
+-- Pretty print a parsing syntax error.
+local function parse_error(self, source, name, errlabel, errpos)
+  name = name or '<source>'
+  local lineno, colno, line = lpegrex.calcline(source, errpos)
+  local colhelp = string.rep(' ', colno-1)..'^'
+  local errmsg = self.errors[errlabel] or errlabel
+  error('syntax error: '..name..':'..lineno..':'..colno..': '..errmsg..
+        '\n'..line..'\n'..colhelp)
+end
+
+-- Parse source into an AST.
+function Parser:parse(source, name)
+  local ast, errlabel, errpos = self.source_patt:match(source)
+  if not ast then
+    parse_error(self, source, name, errlabel, errpos)
+  end
+  return ast
+end
+
+-- Remove left common left indentations from a text.
+local function trim_identantion(text)
+  local initcol, ss = 0x7fffffff, {}
+  -- find common indentation
+  for line in text:gmatch('([^\n]*)\n?') do
+    if #line > 0 then
+      local charcol = line:find('[^%s]')
+      if charcol then
+        initcol = math.min(initcol, charcol)
+      end
+    end
+    ss[#ss+1] = line
+  end
+  -- remove common indentation and trim right
+  for i=1,#ss do
+    ss[i] = ss[i]:sub(initcol):gsub('%s*$', '')
+  end
+  return table.concat(ss, '\n')
+end
+
+-- Trim spaces from comments.
+local function trim_comments(comments)
+  for i=1,#comments do
+    local comment = comments[i]
+    comment.text = trim_identantion(comment.text)
+  end
+  -- remove empty comments
+  local i = 1
+  while i <= #comments do
+    local comment = comments[i]
+    if comment.text == '' then
+      table.remove(comments, i)
+    else
+      i = i + 1
+    end
+  end
+end
+
+-- Calculate comments line numbers.
+local function calc_comments(comments, source)
+  -- gather line number and calc comment texts
+  for i=1,#comments do
+    local comment = comments[i]
+    comment.text, comment[1] = comment[1], nil
+    -- calculate line numbers
+    comment.lineno, comment.colno = lpegrex.calcline(source, comment.pos)
+    comment.endlineno, comment.endcolno = lpegrex.calcline(source, comment.endpos-1)
+  end
+end
+
+-- Combine neighbor comments.
+local function combine_comments(comments, source)
+  local i = 1
+  while i < #comments do
+    local c1 = comments[i]
+    local c2 = comments[i+1]
+    local inbetween = source:sub(c1.endpos, c2.pos-1)
+    if c1.colno == c2.colno and
+       c1.endlineno+1 == c2.lineno and
+       c1.tag == c2.tag and
+       inbetween:match('^%s*$') then
+      comments[i] = {
+        tag = c1.tag,
+        text = c1.text..'\n'..c2.text,
+        pos = c1.pos,
+        endpos = c2.endpos,
+        lineno = c1.lineno,
+        endlineno = c2.endlineno,
+        colno = c1.colno,
+        endcolno = c2.endcolno,
+        combined = true,
+      }
+      table.remove(comments, i+1)
+    else
+      i = i + 1
+    end
+  end
+  return comments
+end
+
+-- Convert a list of comments to a map of line number and comment.
+local function make_comments_by_line(comments)
+  local comments_by_line = {}
+  for i=1,#comments do
+    local comment = comments[i]
+    for lineno=comment.lineno,comment.endlineno do
+      assert(not comments_by_line[lineno])
+      comments_by_line[lineno] = comment
+    end
+  end
+  return comments_by_line
+end
+
+-- Parse all comments from source into a map and a list of comments.
+function Parser:parse_comments(source, name)
+  local comments, errlabel, errpos = self.comments_patt:match(source)
+  if not comments then
+    parse_error(self, source, name, errlabel, errpos)
+  end
+  calc_comments(comments, source)
+  combine_comments(comments, source)
+  trim_comments(comments)
+  local comments_by_line = make_comments_by_line(comments)
+  return comments_by_line, comments
+end
+
+--------------------------------------------------------------------------------
+-- Nelua Parser
+
+-- Complete syntax grammar of Nelua defined in a single PEG.
+local syntax_grammar = [==[
+chunk           <-- SHEBANG? SKIP Block (!.)^UnexpectedSyntax
+
+Block           <==(local / global /
+                    FuncDef / Return / In /
+                    Do / Defer /
+                    If / Switch /
+                    for /
+                    While / Repeat /
+                    Break / Continue /
+                    Goto / Label /
+                    Preprocess /
+                    Assign / call /
+                    `;`)*
+
+-- Statements
+Label           <== `::` @name @`::`
+Return          <== `return` (expr (`,` @expr)*)?
+In              <== `in` @expr
+Break           <== `break`
+Continue        <== `continue`
+Goto            <== `goto` @name
+Do              <== `do` Block @`end`
+Defer           <== `defer` Block @`end`
+While           <== `while` @expr @`do` Block @`end`
+Repeat          <== `repeat` Block @`until` @expr
+If              <== `if` ifs (`else` Block)? @`end`
+ifs             <-| @expr @`then` Block (`elseif` @expr @`then` Block)*
+Switch          <== `switch` @expr `do`? @cases (`else` Block)? @`end`
+cases           <-| (`case` @exprs @`then` Block)+
+for             <-- `for` (ForNum / ForIn)
+ForNum          <== iddecl `=` @expr @`,` forcmp~? @expr (`,` @expr)~? @`do` Block @`end`
+ForIn           <== @iddecls @`in` @exprs @`do` Block @`end`
+local           <-- `local` (localfunc / localvar)
+global          <-- `global` (globalfunc / globalvar)
+localfunc  : FuncDef  <== `function` $'local' @namedecl @funcbody
+globalfunc : FuncDef  <== `function` $'global' @namedecl @funcbody
+FuncDef         <== `function` $false @funcname @funcbody
+funcbody        <-- `(` funcargs @`)` (`:` @funcrets)~? annots~? Block @`end`
+localvar   : VarDecl  <== $'local' @suffixeddecls (`=` @exprs)?
+globalvar  : VarDecl  <== $'global' @suffixeddecls (`=` @exprs)?
+Assign          <== vars `=` @exprs
+Preprocess      <== PREPROCESS SKIP
+
+-- Simple expressions
+Number          <== NUMBER name? SKIP
+String          <== STRING name? SKIP
+Boolean         <== `true`->totrue / `false`->tofalse
+Nilptr          <== `nilptr`
+Nil             <== `nil`
+Varargs         <== `...`
+Id              <== name
+IdDecl          <== name (`:` @typeexpr)~? annots?
+typeddecl    : IdDecl <== name `:` @typeexpr annots?
+suffixeddecl : IdDecl <== (idsuffixed / name) (`:` @typeexpr)~? annots?
+suffixeddeclexpr  <-- suffixeddecl / PreprocessExpr
+namedecl   : IdDecl <== name
+Function        <== `function` @funcbody
+InitList        <== `{` (field (fieldsep field)* fieldsep?)? @`}`
+field           <-- Pair / expr
+Paren           <== `(` @expr @`)`
+DoExpr          <== `(` `do` Block @`end` @`)`
+Type            <== `@` @typeexpr
+
+Pair            <== `[` @expr @`]` @`=` @expr / name `=` @expr / `=` @id -> pair_sugar
+Annotation      <== name annotargs?
+
+-- Preprocessor replaceable nodes
+PreprocessExpr  <== `#[` {@expr->0} @`]#`
+PreprocessName  <== `#|` {@expr->0} @`|#`
+ppcallprim : PreprocessExpr <== {NAME->0} `!` &callsuffix
+
+-- Suffixes
+Call            <== callargs
+CallMethod      <== `:` @name @callargs
+DotIndex        <== `.` @name
+ColonIndex      <== `:` @name
+KeyIndex        <== `[` @expr @`]`
+
+indexsuffix     <-- DotIndex / KeyIndex
+callsuffix      <-- Call / CallMethod
+
+var             <-- (exprprim (indexsuffix / callsuffix+ indexsuffix)+)~>rfoldright /
+                    id / deref
+call            <-- (exprprim (callsuffix / indexsuffix+ callsuffix)+)~>rfoldright
+exprsuffixed    <-- (exprprim (indexsuffix / callsuffix)*)~>rfoldright
+idsuffixed      <-- (id DotIndex+)~>rfoldright
+funcname        <-- (id DotIndex* ColonIndex?)~>rfoldright
+
+-- Lists
+callargs        <-| `(` (expr (`,` @expr)*)? @`)` / InitList / String
+annotargs       <-| `(` (expr (`,` @expr)*)? @`)` / InitList / String / PreprocessExpr
+iddecls         <-| iddecl (`,` @iddecl)*
+funcargs        <-| (iddecl (`,` iddecl)* (`,` VarargsType)? / VarargsType)?
+suffixeddecls   <-| suffixeddeclexpr (`,` @suffixeddeclexpr)*
+exprs           <-| expr (`,` @expr)*
+annots          <-| `<` @Annotation (`,` @Annotation)* @`>`
+funcrets        <-| `(` typeexpr (`,` @typeexpr)* @`)` / typeexpr
+vars            <-| var (`,` @var)*
+
+-- Expression operators
+opor      : BinaryOp  <== `or`->'or' @exprand
+opand     : BinaryOp  <== `and`->'and' @exprcmp
+opcmp     : BinaryOp  <== cmp @exprbor
+opbor     : BinaryOp  <== `|`->'bor' @exprbxor
+opbxor    : BinaryOp  <== `~`->'bxor' @exprband
+opband    : BinaryOp  <== `&`->'band' @exprbshift
+opbshift  : BinaryOp  <== (`<<`->'shl' / `>>>`->'asr' / `>>`->'shr') @exprconcat
+opconcat  : BinaryOp  <== `..`->'concat' @exprconcat
+oparit    : BinaryOp  <== (`+`->'add' / `-`->'sub') @exprfact
+opfact    : BinaryOp  <== (`*`->'mul' / `///`->'tdiv' / `//`->'idiv' / `/`->'div' /
+                           `%%%`->'tmod' / `%`->'mod') @exprunary
+oppow     : BinaryOp  <== `^`->'pow' @exprunary
+opunary   : UnaryOp   <== (`not`->'not' / `-`->'unm' / `#`->'len' /
+                           `~`->'bnot' / `&`->'ref' / `$`->'deref') @exprunary
+deref     : UnaryOp   <== `$`->'deref' @exprunary
+
+-- Expressions
+expr            <-- expror
+expror          <-- (exprand opor*)~>foldleft
+exprand         <-- (exprcmp opand*)~>foldleft
+exprcmp         <-- (exprbor opcmp*)~>foldleft
+exprbor         <-- (exprbxor opbor*)~>foldleft
+exprbxor        <-- (exprband opbxor*)~>foldleft
+exprband        <-- (exprbshift opband*)~>foldleft
+exprbshift      <-- (exprconcat opbshift*)~>foldleft
+exprconcat      <-- (exprarit opconcat*)~>foldleft
+exprarit        <-- (exprfact oparit*)~>foldleft
+exprfact        <-- (exprunary opfact*)~>foldleft
+exprunary       <-- opunary / exprpow
+exprpow         <-- (exprsimple oppow*)~>foldleft
+exprsimple      <-- Number / String / Type / InitList / Boolean /
+                    Function / Nilptr / Nil / Varargs / exprsuffixed
+exprprim        <-- ppcallprim / id / DoExpr / Paren
+
+-- Types
+RecordType      <== 'record' WORDSKIP @`{` (RecordField (fieldsep RecordField)* fieldsep?)? @`}`
+UnionType       <== 'union' WORDSKIP @`{` (UnionField (fieldsep UnionField)* fieldsep?)? @`}`
+EnumType        <== 'enum' WORDSKIP (`(` @typeexpr @`)`)~? @`{` @enumfields @`}`
+FuncType        <== 'function' WORDSKIP @`(` functypeargs @`)`(`:` @funcrets)?
+ArrayType       <== 'array' WORDSKIP @`(` @typeexpr (`,` @expr)? @`)`
+PointerType     <== 'pointer' WORDSKIP (`(` @typeexpr @`)`)?
+VariantType     <== 'variant' WORDSKIP `(` @typearg (`,` @typearg)* @`)`
+VarargsType     <== `...` (`:` @name)?
+
+RecordField     <== name @`:` @typeexpr
+UnionField      <== name `:` @typeexpr / $false typeexpr
+EnumField       <== name (`=` @expr)?
+
+-- Type lists
+enumfields      <-| EnumField (fieldsep EnumField)* fieldsep?
+functypeargs    <-| (functypearg (`,` functypearg)* (`,` VarargsType)? / VarargsType)?
+typeargs        <-| typearg (`,` @typearg)*
+
+functypearg     <-- typeddecl / typeexpr
+typearg         <-- typeexpr / `(` expr @`)` / expr
+
+-- Type expression operators
+typeopptr : PointerType   <== `*`
+typeopopt : OptionalType  <== `?`
+typeoparr : ArrayType     <== `[` expr? @`]`
+typeopvar : VariantType   <== typevaris
+typeopgen : GenericType   <== `(` @typeargs @`)` / &`{` {| InitList |}
+typevaris : VariantType   <== `|` @typeexprunary (`|` @typeexprunary)*
+
+typeopunary     <-- typeopptr / typeopopt / typeoparr
+
+-- Type expressions
+typeexpr        <-- (typeexprunary typevaris?)~>foldleft
+typeexprunary   <-- (typeopunary* typexprsimple)->rfoldleft
+typexprsimple   <-- RecordType / UnionType / EnumType / FuncType / ArrayType / PointerType /
+                    VariantType / (typeexprprim typeopgen?)~>foldleft
+typeexprprim    <-- idsuffixed / id
+
+-- Common rules
+name            <-- NAME SKIP / PreprocessName
+id              <-- Id / PreprocessExpr
+iddecl          <-- IdDecl / PreprocessExpr
+cmp             <-- `==`->'eq' / forcmp
+forcmp          <-- `~=`->'ne' / `<=`->'le' / `<`->'lt' / `>=`->'ge' / `>`->'gt'
+fieldsep        <-- `,` / `;`
+
+-- String
+STRING          <-- STRING_SHRT / STRING_LONG
+STRING_LONG     <-- {:LONG_OPEN {LONG_CONTENT} @LONG_CLOSE:}
+STRING_SHRT     <-- {:QUOTE_OPEN {~QUOTE_CONTENT~} @QUOTE_CLOSE:}
+QUOTE_OPEN      <-- {:qe: ['"] :}
+QUOTE_CONTENT   <-- (ESCAPE_SEQ / !(QUOTE_CLOSE / LINEBREAK) .)*
+QUOTE_CLOSE     <-- =qe
+ESCAPE_SEQ      <-- '\'->'' @ESCAPE
+ESCAPE          <-- [\'"] /
+                    ('n' $10 / 't' $9 / 'r' $13 / 'a' $7 / 'b' $8 / 'v' $11 / 'f' $12)->tochar /
+                    ('x' {HEX_DIGIT^2} $16)->tochar /
+                    ('u' '{' {HEX_DIGIT^+1} '}' $16)->toutf8char /
+                    ('z' SPACE*)->'' /
+                    (DEC_DIGIT DEC_DIGIT^-1 !DEC_DIGIT / [012] DEC_DIGIT^2)->tochar /
+                    (LINEBREAK $10)->tochar
+
+-- Number
+NUMBER          <-- {HEX_NUMBER / BIN_NUMBER / DEC_NUMBER}
+HEX_NUMBER      <-- '0' [xX] @HEX_PREFIX ([pP] @EXP_DIGITS)?
+BIN_NUMBER      <-- '0' [bB] @BIN_PREFIX ([pP] @EXP_DIGITS)?
+DEC_NUMBER      <-- DEC_PREFIX ([eE] @EXP_DIGITS)?
+HEX_PREFIX      <-- HEX_DIGIT+ ('.' HEX_DIGIT*)? / '.' HEX_DIGIT+
+BIN_PREFIX      <-- BIN_DIGITS ('.' BIN_DIGITS?)? / '.' BIN_DIGITS
+DEC_PREFIX      <-- DEC_DIGIT+ ('.' DEC_DIGIT*)? / '.' DEC_DIGIT+
+EXP_DIGITS      <-- [+-]? DEC_DIGIT+
+
+-- Comments
+COMMENT         <-- '--' (COMMENT_LONG / COMMENT_SHRT)
+COMMENT_LONG    <-- (LONG_OPEN LONG_CONTENT @LONG_CLOSE)->0
+COMMENT_SHRT    <-- (!LINEBREAK .)*
+
+-- Preprocess
+PREPROCESS      <-- '##' (PREPROCESS_LONG / PREPROCESS_SHRT)
+PREPROCESS_LONG <-- {:'[' {:eq: '='*:} '[' {LONG_CONTENT} @LONG_CLOSE:}
+PREPROCESS_SHRT <-- {(!LINEBREAK .)*} LINEBREAK?
+
+-- Long (used by string, comment and preprocess)
+LONG_CONTENT    <-- (!LONG_CLOSE .)*
+LONG_OPEN       <-- '[' {:eq: '='*:} '[' LINEBREAK?
+LONG_CLOSE      <-- ']' =eq ']'
+
+NAME            <-- !KEYWORD {NAME_PREFIX NAME_SUFFIX?}
+NAME_PREFIX     <-- [_a-zA-Z%utf8seq]
+NAME_SUFFIX     <-- [_a-zA-Z0-9%utf8seq]+
+
+-- Miscellaneous
+SHEBANG         <-- '#!' (!LINEBREAK .)* LINEBREAK?
+SKIP            <-- (SPACE+ / COMMENT)*
+WORDSKIP        <-- !NAME_SUFFIX SKIP
+LINEBREAK       <-- %cn %cr / %cr %cn / %cn / %cr
+SPACE           <-- %sp
+HEX_DIGIT       <-- [0-9a-fA-F]
+BIN_DIGITS      <-- [01]+ !DEC_DIGIT
+DEC_DIGIT       <-- [0-9]
+EXTRA_TOKENS    <-- `[[` `[=` `--` `##` -- Force defining these tokens.
+]==]
+
+-- Grammar parsing only commends and ignoring the rest.
+local comments_grammar = [==[
+comments        <-| (LongComment / ShortComment / .)*
+
+LongComment    <== '--' LONG_OPEN LINEBREAK_SKIP {LONG_CONTENT} @LONG_CLOSE
+ShortComment   <== '--' SHORT_SKIP {(!(SHORT_SKIP LINEBREAK) .)*} SHORT_SKIP
+
+SHORT_SKIP      <-- (SPACE / '-')*
+
+LONG_CONTENT    <-- (!LONG_CLOSE .)*
+LONG_OPEN       <-- '[' {:eq: '='*:} '['
+LONG_CLOSE      <-- SKIP ']' =eq ']'
+
+SKIP            <-- %sp*
+LINEBREAK_SKIP  <-- (SPACE* LINEBREAK)?
+SPACE           <-- [ %ct%cf%cv]
+LINEBREAK       <-- %cn %cr / %cr %cn / %cn / %cr
+]==]
+
+-- List of syntax errors.
+local syntax_errors = {
+["Expected_do"]             = "expected `do` keyword to begin a statement block",
+["Expected_then"]           = "expected `then` keyword to begin a statement block",
+["Expected_end"]            = "expected `end` keyword to close a statement block",
+["Expected_until"]          = "expected `until` keyword to close a `repeat` statement",
+["Expected_cases"]          = "expected `case` keyword in `switch` statement",
+["Expected_in"]             = "expected `in` keyword in `for` statement",
+["Expected_Annotation"]     = "expected an annotation expression",
+["Expected_expr"]           = "expected an expression",
+["Expected_exprand"]        = "expected an expression after operator",
+["Expected_exprcmp"]        = "expected an expression after operator",
+["Expected_exprbor"]        = "expected an expression after operator",
+["Expected_exprbxor"]       = "expected an expression after operator",
+["Expected_exprband"]       = "expected an expression after operator",
+["Expected_exprbshift"]     = "expected an expression after operator",
+["Expected_exprconcat"]     = "expected an expression after operator",
+["Expected_exprfact"]       = "expected an expression after operator",
+["Expected_exprunary"]      = "expected an expression after operator",
+["Expected_name"]           = "expected an identifier name",
+["Expected_namedecl"]       = "expected an identifier name",
+["Expected_Id"]             = "expected an identifier name",
+["Expected_IdDecl"]         = "expected an identifier declaration",
+["Expected_typearg"]        = "expected an argument in type expression",
+["Expected_typeexpr"]       = "expected a type expression",
+["Expected_typeexprunary"]  = "expected a type expression",
+["Expected_funcbody"]       = "expected function body",
+["Expected_funcrets"]       = "expected function return types",
+["Expected_funcname"]       = "expected a function name",
+["Expected_globaldecl"]     = "expected a global identifier declaration",
+["Expected_var"]            = "expected a variable",
+["Expected_enumfields"]     = "expected a field in `enum` type",
+["Expected_typeargs"]       = "expected arguments in type expression",
+["Expected_callargs"]       = "expected call arguments",
+["Expected_exprs"]          = "expected expressions",
+["Expected_globaldecls"]    = "expected global identifiers declaration",
+["Expected_iddecls"]        = "expected identifiers declaration",
+["Expected_("]              = "expected parenthesis `(`",
+["Expected_,"]              = "expected comma `,`",
+["Expected_:"]              = "expected colon `:`",
+["Expected_="]              = "expected equals `=`",
+["Expected_{"]              = "expected curly brace `{`",
+["Expected_)"]              = "unclosed parenthesis, did you forget a `)`?",
+["Expected_::"]             = "unclosed label, did you forget a `::`?",
+["Expected_>"]              = "unclosed angle bracket, did you forget a `>`?",
+["Expected_]"]              = "unclosed square bracket, did you forget a `]`?",
+["Expected_}"]              = "unclosed curly brace, did you forget a `}`?",
+["Expected_]#"]             = "unclosed preprocess expression, did you forget a `]#`?",
+["Expected_|#"]             = "unclosed preprocess name, did you forget a `|#`?",
+["Expected_LONG_CLOSE"]     = "unclosed long, did you forget a `]]`?",
+["Expected_QUOTE_CLOSE"]    = "unclosed string, did you forget a quote?",
+["Expected_ESCAPE"]         = "malformed escape sequence",
+["Expected_BIN_PREFIX"]     = "malformed binary number",
+["Expected_EXP_DIGITS"]     = "malformed exponential number",
+["Expected_HEX_PREFIX"]     = "malformed hexadecimal number",
+["UnexpectedSyntax"]        = "unexpected syntax",
+}
+
+local defs = {}
+
+-- Auxiliary function for 'Pair' syntax sugar.
+function defs.pair_sugar(idnode)
+  return idnode[1], idnode
+end
+
+local parser = Parser.create(syntax_grammar, comments_grammar, syntax_errors, defs)
+
+--------------------------------------------------------------------------------
+-- Emitter class, used to emit large texts.
+
+-- The emitter class.
+local Emitter = {}
+Emitter.__index = Emitter
+
+-- Creates a new emitter.
+function Emitter.create()
+  return setmetatable({}, Emitter)
+end
+
+-- Appends a text.
+function Emitter:add(s)
+  self[#self+1] = s
+end
+
+-- Combine all texts.
+function Emitter:generate()
+  return table.concat(self)
+end
+
+--------------------------------------------------------------------------------
+-- Generator class, used to generate the documentation.
+
+-- The generator class.
+local Generator = {}
+local Generator_mt = {__index = Generator}
+
+-- Default symbol template.
+local symbol_template = [[
+### $(name)
+
+```$(lang)
+$(code)
+```
+
+$(text)
+
+]]
+
+-- Default heading template.
+local top_template = [[
+## $(name)
+
+$(text)
+
+]]
+
+local bottom_template = [[
+---
+]]
+
+-- Create a new generator from visitors.
+function Generator.create(visitors, lang)
+  return setmetatable({
+    top_template = top_template,
+    symbol_template = symbol_template,
+    bottom_template = bottom_template,
+    lang = lang,
+    visitors = visitors
+  }, Generator_mt)
+end
+
+-- Emit documentation.
+function Generator:emit(source, filename, ast, comments, options, emitter)
+  -- setup options
+  options = options or {}
+  options.include_names = options.include_names or {}
+  options.top_template = options.top_template or self.top_template
+  options.symbol_template = options.symbol_template or self.symbol_template
+  -- create emitter
+  if not emitter then
+    emitter = Emitter.create()
+  end
+  -- create context
+  local context = {
+    ast = ast,
+    source = source,
+    filename = filename,
+    mod_symbol_name = '',
+    options = options,
+    comments = comments,
+    lang = self.lang,
+    symbols = {},
+  }
+  local visitors = self.visitors
+  -- emit top heading
+  local topcomment = comments[1]
+  if topcomment and visitors.TopComment then
+    visitors.TopComment(context, topcomment, emitter)
+  end
+  -- get the module symbol name
+  local last_node = ast[#ast]
+  if last_node.tag and last_node.tag == 'Return' then
+    context.mod_symbol_name = last_node[1][1]
+  end
+
+  -- emit nodes
+  for node, parent in walk_nodes(ast) do
+    node.parent = parent
+    local visit = visitors[node.tag]
+    if visit then
+      visit(context, node, emitter)
+    end
+  end
+  emitter:add(bottom_template)
+  return emitter
+end
+
+--------------------------------------------------------------------------------
+-- Nelua documentation generator
+
+local substitute_vars_mt = {}
+local substitute_vars = setmetatable({}, substitute_vars_mt)
+local substitute_defs = {}
+function substitute_defs.to_var(k)
+  local v = substitute_vars[k]
+  return v ~= nil and tostring(v) or ''
+end
+local substitute_patt = lpegrex.compile([[
+  pat <- {~ (var / .)* ~}
+  var <- ('$(' {[_%a]+} ')') -> to_var
+]], substitute_defs)
+
+-- Substitute keywords between '$()' from a text using values from a table.
+local function template_substitute(format, vars)
+  substitute_vars_mt.__index = vars
+  return substitute_patt:match(format)
+end
+
+-- Trim comments on the right.
+local function rtrim_comments(text)
+  text = text:gsub('%s*%-%-%[=*%[.*$', '') -- trim multi line comments
+  repeat
+    local n
+    text, n = text:gsub('%s%-%-[^\n]*%s*$', '')
+  until n == 0
+  return text
+end
+
+-- Trim unwanted text in declarations.
+local function trimdecl(text)
+  return rtrim_comments(text) -- remove trailing comments
+             :gsub('%s*$', '') -- remove trailing spaces
+             :gsub('%s*%b<>$', '') -- remove annotations
+end
+
+-- Trim unwanted text in definitions.
+local function trimdef(text)
+  text = rtrim_comments(text) -- remove trailing comments
+             :gsub('%s*$', '') -- remove trailing spaces
+
+  return text
+end
+
+-- Filter symbol by name.
+local function document_symbol(context, symbol, emitter)
+  if not symbol.name then
+    -- probably a preprocessor name, ignore
+    return false
+  end
+  local mod_symbol_name, symbols, inclnames = context.mod_symbol_name, context.symbols, context.options.include_names
+  local classname = symbol.name:match('(.*)[.:][_%w]+$')
+  local is_class_module = symbol.name == mod_symbol_name or classname == mod_symbol_name
+
+  if classname and not symbols[classname] and not inclnames[classname] then
+    -- class symbol is not wanted
+    return false
+  end
+  if not symbol.topscope or (symbol.declscope == 'local' and not is_class_module and not inclnames[symbol.name]) then
+    -- not a global, module or wanted symbol
+    return false
+  end
+  table.insert(symbols, symbol)
+  symbols[symbol.name] = true
+  emitter:add(template_substitute(context.options.symbol_template, symbol))
+  return true
+end
+
+-- Generator visitors.
+local visitors = {}
+
+-- Visit top most comment.
+function visitors.TopComment(context, comment, emitter)
+  local filename = context.filename
+  local name = context.options.name
+  if not name then
+    name = filename:match('([_%w]+)%.[_%w]+$') or filename
+    context.name = name
+  end
+  local consts = {
+    name = name,
+    filename = filename,
+    text = comment.text,
+  }
+  emitter:add(template_substitute(context.options.top_template, consts))
+end
+
+-- Visit function definitions.
+function visitors.FuncDef(context, node, emitter)
+  local declscope = node[1]
+  local blocknode = node[6]
+  local lineno = lpegrex.calcline(context.source, node.pos)
+  local chunk = context.source:sub(node.pos, blocknode.pos-1)
+  local name = chunk:match('function%s+([^%(]*)%s*%(')
+  local comment = context.comments[lineno-1]
+  local decl = trimdecl(chunk)
+  local code = declscope and declscope..' '..decl or decl
+  local symbol = {
+    tag = node.tag,
+    name = name,
+    code = code,
+    comment = comment,
+    text = comment and comment.text,
+    lineno = lineno,
+    topscope = node.parent == context.ast,
+    declscope = declscope,
+    node = node,
+    lang = context.lang,
+  }
+  document_symbol(context, symbol, emitter)
+end
+
+-- Visit variable declarations.
+function visitors.VarDecl(context, node, emitter)
+  local declscope = node[1]
+  local varnodes = node[2]
+  local valnodes = node[3]
+  for i,varnode in ipairs(varnodes) do
+    local valnode = valnodes and valnodes[i]
+    local lineno = lpegrex.calcline(context.source, varnode.pos)
+    local chunk = context.source:sub(varnode.pos, varnode.endpos-1)
+    local comment = context.comments[lineno-1]
+    local decl = trimdecl(chunk)
+    local name = decl:match('^[_%.%w]+')
+    local code = declscope and declscope..' '..decl or decl
+    if valnode then
+      local valpos, valendpos = valnode.pos, valnode.endpos
+      for vnode in walk_nodes(valnode) do
+        valpos = math.min(valpos, vnode.pos)
+        valendpos = math.max(valendpos, vnode.endpos)
+      end
+      local def = trimdef(context.source:sub(valpos, valendpos-1))
+      if def:find('^@') then
+        code = code..' = '..def
+      end
+    end
+    local symbol = {
+      tag = node.tag,
+      name = name,
+      code = code,
+      comment = comment,
+      text = comment and comment.text,
+      lineno = lineno,
+      topscope = node.parent == context.ast,
+      declscope = declscope,
+      node = node,
+      lang = context.lang,
+    }
+    document_symbol(context, symbol, emitter)
+  end
+end
+
+local generator = Generator.create(visitors, 'nelua')
+
+--[[
+Generate documentation from a source file.
+All the code resumes to this single function.
+]]
+local function generate_doc(emitter, filename, options)
+  local source = read_file(filename)
+  local ast = parser:parse(source, filename)
+  local comments = parser:parse_comments(source, filename)
+  generator:emit(source, filename, ast, comments, options, emitter)
+end
+
+local nldoc = {
+  -- Utilities
+  walk_nodes = walk_nodes,
+  read_file = read_file,
+  write_file = write_file,
+
+  -- Parser
+  Parser = Parser,
+  syntax_grammar = syntax_grammar,
+  comments_grammar = comments_grammar,
+  syntax_errors = syntax_errors,
+  defs = defs,
+  parser = parser,
+
+  -- Generator
+  Emitter = Emitter,
+  Generator = Generator,
+  visitors = visitors,
+  generator = generator,
+
+  -- The most important function.
+  generate_doc = generate_doc,
+}
+
+return nldoc
+


### PR DESCRIPTION
To generate documentation, just use the following command:

```
$ nelua --script gen-docs.lua
```

On the end of gen-docs script there are all the `doc_dir` calls, which is what generates documentation for each directory:

```lua
doc_dir('engine/', '')
doc_dir('engine/event/', 'event/')
doc_dir('engine/event-manager/', 'event-manager/')
doc_dir('engine/fileystem/', 'fileystem/')
doc_dir('engine/gui/', 'gui/')
doc_dir('engine/information-handler/', 'information-handler/')
doc_dir('engine/mouse/', 'mouse/')
doc_dir('engine/obj2d/', 'obj2d/')
doc_dir('engine/obj3d/', 'obj3d/')
doc_dir('engine/render/', 'render/')
doc_dir('engine/transform/', 'transform/')
doc_dir('engine/uimanager/', 'uimanager/')
doc_dir('engine/utilities/', 'utilities/')
``` 

If you make a new directory, you need to add a new `doc_dir` call for this directory, and also make the respective directory on the `docs` folder.

The same applies if you remove a directory.

This uses a patched version of [nldoc](https://github.com/Andre-LA/nene/blob/main/nldoc.lua)